### PR TITLE
Fix #27: Added SQLite database files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# SQLite database files
+*.db
+*.sqlite3
+*.sqlite
+
+# Database folder
+database/
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Virtual environment
+venv/
+.env
+
+# OS files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
This PR addresses Issue #27 by adding SQLite database files and related directories to the .gitignore file.

Currently, database files and local environment artifacts risk being accidentally committed to the repository, which can lead to unnecessary repository bloat, security concerns, and inconsistent development environments.

Changes made:
- Added SQLite database extensions (*.db, *.sqlite, *.sqlite3) to .gitignore
- Ignored database/ directory
- Excluded Python cache files, virtual environments, and OS-specific artifacts

This improves repository hygiene and aligns with standard open-source best practices.

This contribution is made as part of OSCG’26 open-source participation.

Please let me know if any adjustments are required.
