### PR TITLE
Improve Theme Toggle with System Preference Detection  #77

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,24 +1,35 @@
 document.addEventListener("DOMContentLoaded", function () {
-    const toggleButton = document.getElementById("mode-toggle");
-    
-    // Check for saved theme preference
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'light') {
-      document.body.classList.add("light-mode");
-      toggleButton.textContent = "Light Mode ☀️";
+  const toggleButton = document.getElementById("mode-toggle");
+  const systemPrefersLight = window.matchMedia("(prefers-color-scheme: light)");
+
+  function setLightMode(isLight, save = true) {
+    document.body.classList.toggle("light-mode", isLight);
+    toggleButton.textContent = isLight ? "Light Mode ☀️" : "Dark Mode 🌙";
+    if (save) {
+      localStorage.setItem("theme", isLight ? "light" : "dark");
     }
-    
-    // Toggle theme when button is clicked
-    toggleButton.addEventListener("click", function () {
-      document.body.classList.toggle("light-mode");
-      
-      // Update button text based on current mode
-      if (document.body.classList.contains("light-mode")) {
-        toggleButton.textContent = "Light Mode ☀️";
-        localStorage.setItem('theme', 'light');
-      } else {
-        toggleButton.textContent = "Dark Mode 🌙";
-        localStorage.setItem('theme', 'dark');
-      }
-    });
+  }
+
+  // Check saved theme
+  const savedTheme = localStorage.getItem("theme");
+
+  if (savedTheme) {
+    setLightMode(savedTheme === "light", false);
+  } else {
+    // No saved theme → follow system preference
+    setLightMode(systemPrefersLight.matches, false);
+  }
+
+  // Toggle theme on button click (manual override)
+  toggleButton.addEventListener("click", function () {
+    const isLight = !document.body.classList.contains("light-mode");
+    setLightMode(isLight);
   });
+
+  // Optional: live update if system theme changes (only if no manual override)
+  systemPrefersLight.addEventListener("change", (e) => {
+    if (!localStorage.getItem("theme")) {
+      setLightMode(e.matches, false);
+    }
+  });
+});


### PR DESCRIPTION
The current theme toggle implementation only supports **manual switching** and has several usability gaps:

- Does not respect the user’s **system (OS) theme preference**
-  First-time visitors always load the same theme
-  No fallback behavior when `localStorage` is empty
-  Theme selection is static and not adaptive

### Goal

Make the theme selection **smart, adaptive, and user-friendly** by syncing with the user’s system theme while still allowing manual overrides.

Proposed Solution
Enhance the existing theme toggle with the following improvements:

System Theme Detection

1. Detect OS theme using `prefers-color-scheme`
2. Apply Dark/Light mode automatically on first visit

### Benefits
Better UX for first-time visitors
Consistent behavior for returning users
Modern, OS-aware UI behavior
Fully backward-compatible with existing toggle