### PR TITLE
Remove duplicate dotenv import and initialization

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,9 +12,7 @@ from firebase_config import get_firebase_config, validate_firebase_config
 # Load environment variables from .env file
 load_dotenv()
 
-from dotenv import load_dotenv
 
-load_dotenv()
 
 # ------------------------------------------------------------------
 # App setup


### PR DESCRIPTION
What does this PR do?
- Removes duplicate load_dotenv() import and call in app.py.

Why is this change needed?
- Avoids redundant initialization and improves code readability.

Checklist:
- [x] No breaking changes
- [x] Tested locally
