### PR TITLE
Fix dark mode visibility for achievement filter dropdowns

### DIFF
--- a/templates/student_achievements_1.html
+++ b/templates/student_achievements_1.html
@@ -98,6 +98,19 @@
       background-color: rgba(255, 255, 255, 0.1);
       color: var(--text-color);
     }
+
+    /* Keep dropdowns readable in dark mode only */
+    body:not(.light-mode) .filter-options select,
+    body:not(.light-mode) .filter-options input {
+      background-color: #1f1f1f;
+      border-color: #4d4d4d;
+      color: #f5f5f5;
+    }
+
+    body:not(.light-mode) .filter-options select option {
+      background-color: #1f1f1f;
+      color: #f5f5f5;
+    }
     
     .achievement-list {
       margin-top: 20px;


### PR DESCRIPTION
## Summary
Fixes visibility issues with dropdown/select elements on the
"My Achievements" page when dark mode is enabled.

## Problem
In dark mode, dropdown options and selected values were not clearly visible,
making filters difficult to use.

## Changes
- Updated CSS styles for dropdown/select elements in dark mode
- Ensured proper text and background contrast
- Improved usability of achievement filters

## Screens Affected
- My Achievements page
- Achievement filter dropdowns

## How to Test
1. Enable dark mode
2. Navigate to My Achievements page
3. Open achievement filter dropdowns
4. Verify options and selected values are clearly visible

## Notes
- UI-only change
- No backend or database impact

Closes #151
