### PR TITLE
feat: add LinkedIn sharing with pre-filled caption copy on card export (closes #521)

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ def make_session_permanent():
 
 # ✅ Portable DB path (works on Windows/Linux/Vercel)
 DB_PATH = os.path.join(os.path.dirname(__file__), "ams.db")
+app.config["DB_PATH"] = DB_PATH
 
 # Define upload folder path for certificates
 UPLOAD_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "static", "uploads")

--- a/static/css/achievement-card.css
+++ b/static/css/achievement-card.css
@@ -570,3 +570,29 @@ body {
 .qr-code {
     background-color: white !important;
 }
+
+/* ========================= */
+/* LINKEDIN BUTTON STYLES */
+/* ========================= */
+
+.btn-linkedin {
+    background: #0077b5;
+    color: white;
+    box-shadow: 0 4px 15px rgba(0, 119, 181, 0.3);
+}
+
+.btn-linkedin:hover {
+    background: #006396;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 119, 181, 0.4);
+}
+
+.btn-linkedin:active {
+    transform: translateY(0);
+}
+
+.linkedin-icon {
+    display: inline-block;
+    vertical-align: middle;
+    fill: currentColor;
+}

--- a/static/js/achievement-export.js
+++ b/static/js/achievement-export.js
@@ -14,6 +14,7 @@ class AchievementExporter {
     constructor() {
         this.cardElement = document.getElementById('achievement-card-export');
         this.downloadBtn = document.getElementById('btn-download');
+        this.linkedinBtn = document.getElementById('btn-linkedin');
         this.closeBtn = document.getElementById('btn-close');
         this.formatRadios = document.querySelectorAll('input[name="export-format"]');
         this.statusDiv = document.getElementById('export-status');
@@ -29,6 +30,9 @@ class AchievementExporter {
     initEventListeners() {
         if (this.downloadBtn) {
             this.downloadBtn.addEventListener('click', () => this.handleExport());
+        }
+        if (this.linkedinBtn) {
+            this.linkedinBtn.addEventListener('click', () => this.shareLinkedIn());
         }
         if (this.closeBtn) {
             this.closeBtn.addEventListener('click', () => this.handleClose());
@@ -214,10 +218,12 @@ class AchievementExporter {
 
         if (isLoading) {
             this.downloadBtn.disabled = true;
+            if (this.linkedinBtn) this.linkedinBtn.disabled = true;
             this.formatRadios.forEach(radio => radio.disabled = true);
             this.statusDiv.style.display = 'flex';
         } else {
             this.downloadBtn.disabled = false;
+            if (this.linkedinBtn) this.linkedinBtn.disabled = false;
             this.formatRadios.forEach(radio => radio.disabled = false);
             setTimeout(() => {
                 this.statusDiv.style.display = 'none';
@@ -265,6 +271,73 @@ class AchievementExporter {
         
         if (this.statusText) {
             this.statusText.textContent = message;
+        }
+    }
+
+    /**
+     * Share achievement on LinkedIn
+     * Copies a pre-formatted caption to clipboard and opens the share dialog
+     */
+    async shareLinkedIn() {
+        try {
+            // Retrieve details from DOM
+            const rawPosition = this.getAchievementMetadata('achievement-position');
+            const position = rawPosition === 'achievement' ? 'N/A' : rawPosition;
+            
+            const rawEventName = this.getAchievementMetadata('event-name-data');
+            const eventName = rawEventName === 'achievement' ? 'N/A' : rawEventName;
+            
+            const rawOrganizer = this.getAchievementMetadata('achievement-organizer');
+            const organizer = rawOrganizer === 'achievement' ? 'N/A' : rawOrganizer;
+            
+            const rawVerificationUrl = this.getAchievementMetadata('verify-url');
+            const verificationUrl = rawVerificationUrl === 'achievement' ? window.location.origin : rawVerificationUrl;
+
+            // Format caption text
+            const captionText = `I am thrilled to share my achievement! 🎖️ I secured ${position} in "${eventName}" organized by "${organizer}". Verify it here: ${verificationUrl}`;
+
+            // Try to copy to clipboard
+            let copied = false;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                try {
+                    await navigator.clipboard.writeText(captionText);
+                    copied = true;
+                } catch (clipErr) {
+                    console.warn('Clipboard write failed:', clipErr);
+                }
+            }
+
+            // Provide UI feedback
+            if (this.statusDiv) {
+                this.statusDiv.style.display = 'flex';
+                if (copied) {
+                    this.showSuccessMessage('Caption copied! Opening LinkedIn...');
+                } else {
+                    // Graceful fallback display
+                    this.showSuccessMessage('Opening LinkedIn...');
+                }
+                
+                // Reset status spinner/text after a delay
+                setTimeout(() => {
+                    this.statusDiv.style.display = 'none';
+                    // Reset styling to original states
+                    this.statusDiv.style.background = '';
+                    this.statusDiv.style.color = '';
+                    const spinner = this.statusDiv.querySelector('.status-spinner');
+                    if (spinner) {
+                        spinner.textContent = '⏳';
+                        spinner.style.animation = '';
+                    }
+                }, 3000);
+            }
+
+            // Open LinkedIn share dialog in a new tab
+            const shareUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(verificationUrl)}`;
+            window.open(shareUrl, '_blank');
+
+        } catch (error) {
+            console.error('LinkedIn share error:', error);
+            this.showErrorMessage(`Share failed: ${error.message}`);
         }
     }
 

--- a/templates/achievement_export.html
+++ b/templates/achievement_export.html
@@ -53,7 +53,7 @@
 
                     <div class="detail-row">
                         <label>Organization:</label>
-                        <span class="detail-value">{{ achievement.organizer }}</span>
+                        <span class="detail-value achievement-organizer">{{ achievement.organizer }}</span>
                     </div>
 
                     {% if achievement.achievement_description %}
@@ -110,6 +110,12 @@
         <div class="button-group">
             <button id="btn-download" class="btn btn-primary">
                 ⬇️ Download Card
+            </button>
+            <button id="btn-linkedin" class="btn btn-linkedin">
+                <svg class="linkedin-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+                    <path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.779-1.75-1.75s.784-1.75 1.75-1.75 1.75.779 1.75 1.75-.784 1.75-1.75 1.75zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z"/>
+                </svg>
+                Share on LinkedIn
             </button>
             <button id="btn-close" class="btn btn-secondary">
                 ✕ Close


### PR DESCRIPTION
Implement dynamic achievement card export combined with a direct LinkedIn sharing option.

- Adds a premium "Share on LinkedIn" button styled with standard LinkedIn branding colors and SVG logo on the card export interface.
- Extracts the achievement's details (Event, Organizer, Position, Verification URL) from the DOM.
- Copies a details-rich formatted caption to the user's clipboard:
  `I am thrilled to share my achievement! 🎖️ I secured {position} in "{event_name}" organized by "{organizer}". Verify it here: {verification_url}`
- Displays toast/status feedback on success.
- Opens LinkedIn's sharing dialogue in a new tab.

Closes #521